### PR TITLE
is_callable instead of method_exists '__invoke'

### DIFF
--- a/src/React/Espresso/Stack.php
+++ b/src/React/Espresso/Stack.php
@@ -22,7 +22,7 @@ class Stack extends \Pimple
             return new HttpServer($stack['socket']);
         });
 
-        $isFactory = is_object($app) && method_exists($app, '__invoke');
+        $isFactory = is_callable($app);
         $this['app'] = $isFactory ? $this->protectService($app) : $app;
     }
 


### PR DESCRIPTION
Looks more elegant and as an added bonus $app might now be any callable
